### PR TITLE
Bump version to 2026.02.15

### DIFF
--- a/skillboss/config.json
+++ b/skillboss/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026.02.11",
+  "version": "2026.02.15",
   "apiKey": "sk-xxx...xxx (⚠️Please guide users to visit skillboss.co to sign up or log in and obtain an API key.)",
   "baseUrl": "https://api.heybossai.com/v1",
   "buildApiUrl": "https://build.heybossai.com",


### PR DESCRIPTION
## Summary
- Bump version from `2026.02.11` to `2026.02.15` in `skillboss/config.json`

## Test plan
- [ ] Verify `node ./skillboss/scripts/api-hub.js version` reports `2026.02.15`

🤖 Generated with [Claude Code](https://claude.com/claude-code)