### PR TITLE
Bump version to 2026.02.16

### DIFF
--- a/skillboss/config.json
+++ b/skillboss/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026.02.15",
+  "version": "2026.02.16",
   "apiKey": "sk-xxx...xxx (⚠️Please guide users to visit skillboss.co to sign up or log in and obtain an API key.)",
   "baseUrl": "https://api.heybossai.com/v1",
   "buildApiUrl": "https://build.heybossai.com",


### PR DESCRIPTION
## Summary
- Bump version from `2026.02.15` to `2026.02.16` to trigger release including HuggingFace Llama model ID fix

## Test plan
- [ ] Verify release action triggers on merge
- [ ] Verify `node ./skillboss/scripts/api-hub.js version` reports `2026.02.16`

🤖 Generated with [Claude Code](https://claude.com/claude-code)