### PR TITLE
Bump version to 2026.02.161

### DIFF
--- a/skillboss/config.json
+++ b/skillboss/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026.02.16",
+  "version": "2026.02.161",
   "apiKey": "sk-xxx...xxx (⚠️Please guide users to visit skillboss.co to sign up or log in and obtain an API key.)",
   "baseUrl": "https://api.heybossai.com/v1",
   "buildApiUrl": "https://build.heybossai.com",


### PR DESCRIPTION
## Summary
- Bump version to `2026.02.161` to retrigger release with corrected Cloudflare R2 credentials

## Test plan
- [ ] Verify release action uploads zip to correct R2 bucket
- [ ] Verify download works from skillboss.co

🤖 Generated with [Claude Code](https://claude.com/claude-code)