### PR TITLE
Add automated npm and MCP Registry publishing workflows

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -15,18 +15,68 @@ jobs:
       run:
         working-directory: mcp-server
     steps:
-      - uses: actions/checkout@v4
-      
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Get package info
+        id: package
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+          echo "📦 Package: $PACKAGE_NAME@$VERSION"
+
+      - name: Wait for npm package availability
+        run: |
+          echo "⏳ Waiting for npm package to be available..."
+          MAX_ATTEMPTS=30
+          ATTEMPT=0
+          SLEEP_TIME=10
+
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS..."
+
+            if npm view ${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }} version 2>/dev/null; then
+              echo "✅ Package ${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }} is available on npm!"
+              exit 0
+            fi
+
+            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+              echo "Package not yet available, waiting ${SLEEP_TIME}s..."
+              sleep $SLEEP_TIME
+            fi
+          done
+
+          echo "❌ Package not available after $((MAX_ATTEMPTS * SLEEP_TIME)) seconds"
+          echo "Please verify that the npm publish workflow completed successfully"
+          exit 1
+
       - name: Install mcp-publisher
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz
           chmod +x mcp-publisher
-      
+
       - name: Authenticate with GitHub OIDC
         run: ./mcp-publisher login github-oidc
-      
+
       - name: Validate server.json
         run: ./mcp-publisher validate
-      
+
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish
+
+      - name: Create summary
+        run: |
+          echo "## 🎉 Published to MCP Registry" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Package:** ${{ steps.package.outputs.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ steps.package.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The MCP server is now available in the Claude Marketplace!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,98 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (do not actually publish)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for npm provenance
+    defaults:
+      run:
+        working-directory: mcp-server
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build TypeScript
+        run: npm run build
+
+      - name: Verify build output
+        run: |
+          echo "📦 Verifying build output..."
+          if [ ! -d "dist" ]; then
+            echo "❌ dist directory not found!"
+            exit 1
+          fi
+          if [ ! -f "dist/index.js" ]; then
+            echo "❌ dist/index.js not found!"
+            exit 1
+          fi
+          echo "✅ Build output verified"
+          ls -lh dist/
+
+      - name: Publish to npm (dry run)
+        if: github.event.inputs.dry_run == 'true'
+        run: npm publish --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        if: github.event.inputs.dry_run != 'true'
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Get package version
+        id: package
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+          echo "📦 Published: $PACKAGE_NAME@$VERSION"
+
+      - name: Verify npm publication
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          echo "⏳ Waiting for npm package to be available..."
+          sleep 10
+          npm view ${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }} --json || {
+            echo "⚠️ Package not immediately available on npm, but this is normal"
+            echo "   It may take a few moments to propagate"
+          }
+
+      - name: Create summary
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          echo "## 📦 npm Package Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Package:** [${{ steps.package.outputs.name }}](https://www.npmjs.com/package/${{ steps.package.outputs.name }})" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ steps.package.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Installation" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "npx ${{ steps.package.outputs.name }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/mcp-server/.npmignore
+++ b/mcp-server/.npmignore
@@ -1,0 +1,32 @@
+# Source files (we publish only built dist/)
+src/
+tsconfig.json
+
+# Development files
+*.log
+*.tmp
+.DS_Store
+
+# Git
+.git/
+.gitignore
+
+# Node
+node_modules/
+npm-debug.log*
+
+# Testing
+coverage/
+.nyc_output/
+test/
+*.test.ts
+*.test.js
+
+# Build artifacts that shouldn't be published
+*.tsbuildinfo
+
+# Documentation that's already in package
+RELEASE.md
+
+# CI/CD
+.github/

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,147 @@
+# SkillBoss MCP Server
+
+Access 100+ AI models and services through the Model Context Protocol (MCP).
+
+## What is SkillBoss MCP Server?
+
+SkillBoss MCP Server provides a unified interface to interact with over 100 AI services including:
+
+- **LLMs**: Claude, GPT-4, Gemini, DeepSeek, and more
+- **Image Generation**: DALL-E, Midjourney, Stable Diffusion, Flux
+- **Video Generation**: Runway, Luma, Kling AI
+- **Audio/Music**: ElevenLabs, Suno, Google Lyria
+- **And many more AI capabilities**
+
+All through a single API key and MCP-compatible interface.
+
+## Installation
+
+### For Claude Desktop / MCP Clients
+
+Add to your MCP settings configuration:
+
+```json
+{
+  "mcpServers": {
+    "skillboss": {
+      "command": "npx",
+      "args": ["-y", "@skillboss/mcp-server"],
+      "env": {
+        "SKILLBOSS_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+### Using Claude Code CLI
+
+```bash
+claude mcp add skillboss -- npx -y @skillboss/mcp-server
+```
+
+## Getting Your API Key
+
+1. Visit [skillboss.co](https://skillboss.co)
+2. Sign up or log in
+3. Go to your [dashboard](https://skillboss.co/dashboard) to get your API key
+
+## Usage
+
+Once installed, the MCP server provides tools to your AI assistant for:
+
+- Generating images, videos, audio, and music
+- Accessing various LLM models
+- Text-to-speech and speech-to-text
+- And more AI capabilities
+
+Simply ask your AI assistant to use these capabilities naturally in conversation.
+
+## Features
+
+- **100+ AI Services** - One API key for dozens of AI providers
+- **MCP Native** - Built specifically for the Model Context Protocol
+- **Unified Interface** - Consistent API across all services
+- **Simple Setup** - Install with npx, configure with one API key
+- **Actively Maintained** - Regular updates with new models and features
+
+## Configuration
+
+### Environment Variables
+
+- `SKILLBOSS_API_KEY` (required) - Your SkillBoss API key from [skillboss.co/dashboard](https://skillboss.co/dashboard)
+
+### MCP Server Settings
+
+The server runs using stdio transport and communicates via JSON-RPC with your MCP client.
+
+## Development
+
+### Building from Source
+
+```bash
+git clone https://github.com/heeyo-life/skillboss-skills.git
+cd skillboss-skills/mcp-server
+npm install
+npm run build
+```
+
+### Running Locally
+
+```bash
+npm run dev
+```
+
+### Testing the Server
+
+```bash
+node dist/index.js
+```
+
+The server will start and communicate via stdin/stdout using the MCP protocol.
+
+## Release Process
+
+See [RELEASE.md](./RELEASE.md) for detailed instructions on publishing new versions to npm and the MCP Registry.
+
+## Documentation
+
+- [SkillBoss Documentation](https://skillboss.co/docs)
+- [MCP Server Integration Guide](https://skillboss.co/docs/integrations/mcp-server)
+- [API Reference](https://skillboss.co/docs/api)
+- [Model Context Protocol Spec](https://modelcontextprotocol.io)
+
+## Repository Structure
+
+```
+mcp-server/
+├── src/           # TypeScript source code
+├── dist/          # Compiled JavaScript (generated)
+├── package.json   # Package configuration
+├── server.json    # MCP Registry configuration
+├── tsconfig.json  # TypeScript configuration
+├── README.md      # This file
+└── RELEASE.md     # Release process documentation
+```
+
+## Support
+
+- **Documentation**: [skillboss.co/docs](https://skillboss.co/docs)
+- **Email**: support@skillboss.co
+- **Discord**: [Join our community](https://discord.gg/U9eM6Vn6g7)
+- **Issues**: [GitHub Issues](https://github.com/heeyo-life/skillboss-skills/issues)
+
+## License
+
+MIT License - See [LICENSE](../LICENSE) file for details
+
+## Links
+
+- [npm Package](https://www.npmjs.com/package/@skillboss/mcp-server)
+- [GitHub Repository](https://github.com/heeyo-life/skillboss-skills)
+- [SkillBoss Website](https://skillboss.co)
+- [Model Context Protocol](https://modelcontextprotocol.io)
+
+---
+
+Made with care by the [SkillBoss](https://skillboss.co) team

--- a/mcp-server/RELEASE.md
+++ b/mcp-server/RELEASE.md
@@ -1,0 +1,281 @@
+# MCP Server Release Process
+
+This document explains how to release the SkillBoss MCP Server to npm and the Claude Marketplace (MCP Registry).
+
+## Overview
+
+When you create a GitHub release, two automated workflows execute in sequence:
+
+1. **npm Publish** - Publishes the package to npm
+2. **MCP Registry Publish** - Publishes the package to the Claude Marketplace
+
+Both workflows are triggered by creating a GitHub release tag.
+
+## Prerequisites
+
+### Required GitHub Secrets
+
+Before you can publish, ensure these secrets are configured in your GitHub repository:
+
+1. **NPM_TOKEN** (Required)
+   - Go to [npmjs.com](https://www.npmjs.com) and log in
+   - Navigate to Access Tokens in your account settings
+   - Create a new "Automation" token (or "Classic" token with publish permissions)
+   - Add it to GitHub: Settings → Secrets and variables → Actions → New repository secret
+   - Name: `NPM_TOKEN`
+   - Value: Your npm token (starts with `npm_...`)
+
+2. **GitHub OIDC** (Automatic)
+   - No setup required - GitHub OIDC tokens are automatically provided by GitHub Actions
+   - The workflow uses `id-token: write` permission to authenticate with the MCP Registry
+
+## Release Steps
+
+### 1. Prepare the Release
+
+Before creating a release, ensure:
+
+1. All changes are merged to the `main` branch
+2. The version in `package.json` has been updated
+3. Tests pass and the package builds successfully locally
+
+```bash
+cd mcp-server
+npm install
+npm run build
+npm run test  # if you have tests
+```
+
+### 2. Create a Git Tag
+
+Create a new tag matching the version in `package.json`:
+
+```bash
+# Example: if package.json version is "1.0.2"
+git tag v1.0.2
+git push origin v1.0.2
+```
+
+### 3. Create GitHub Release
+
+You can create a release via:
+
+**Option A: GitHub CLI**
+```bash
+gh release create v1.0.2 \
+  --title "v1.0.2" \
+  --notes "Release notes go here"
+```
+
+**Option B: GitHub Web UI**
+1. Go to your repository on GitHub
+2. Click "Releases" → "Draft a new release"
+3. Choose the tag you created (v1.0.2)
+4. Add a title and description
+5. Click "Publish release"
+
+### 4. Monitor the Workflows
+
+After creating the release:
+
+1. Go to Actions tab in your GitHub repository
+2. Watch the workflows execute:
+   - **Publish to npm** - should complete in ~2-3 minutes
+   - **Publish to MCP Registry** - starts automatically after npm publish, completes in ~2-3 minutes
+
+### 5. Verify Publication
+
+**Verify npm:**
+```bash
+npm view @skillboss/mcp-server
+```
+
+**Verify MCP Registry:**
+- Visit the Claude Marketplace
+- Search for "SkillBoss"
+- Your package should appear with the new version
+
+## Workflow Details
+
+### npm Publish Workflow
+
+**File:** `.github/workflows/npm-publish.yml`
+
+**Triggers:**
+- On release publication
+- Manual dispatch (with optional dry-run)
+
+**Steps:**
+1. Checkout code
+2. Setup Node.js 20
+3. Install dependencies (`npm ci`)
+4. Build TypeScript (`npm run build`)
+5. Verify build output
+6. Publish to npm with provenance
+7. Verify publication
+
+**Key Features:**
+- Uses npm provenance for supply chain security
+- Publishes as public scoped package (`--access public`)
+- Includes build verification before publishing
+- Dry-run mode available for testing
+
+### MCP Registry Publish Workflow
+
+**File:** `.github/workflows/mcp-registry-publish.yml`
+
+**Triggers:**
+- On release publication
+- Manual dispatch
+
+**Steps:**
+1. Checkout code
+2. Get package information
+3. **Wait for npm package** (polls for up to 5 minutes)
+4. Download mcp-publisher tool
+5. Authenticate with GitHub OIDC
+6. Validate server.json
+7. Publish to MCP Registry
+
+**Key Features:**
+- Automatically waits for npm package to be available
+- Retries for up to 5 minutes with 10-second intervals
+- Uses GitHub OIDC for secure authentication
+- Validates server configuration before publishing
+
+## Manual Workflow Dispatch
+
+Both workflows support manual triggering for testing or re-publishing:
+
+```bash
+# Trigger npm publish (dry run)
+gh workflow run npm-publish.yml -f dry_run=true
+
+# Trigger npm publish (actual)
+gh workflow run npm-publish.yml
+
+# Trigger MCP registry publish
+gh workflow run mcp-registry-publish.yml
+```
+
+## Troubleshooting
+
+### npm Publish Fails
+
+**Problem:** "npm ERR! 401 Unauthorized"
+- **Solution:** Check that NPM_TOKEN is set correctly in GitHub secrets
+
+**Problem:** "npm ERR! 403 Forbidden"
+- **Solution:** Ensure you have publish permissions for @skillboss scope on npm
+
+**Problem:** Build files missing
+- **Solution:** Check that `npm run build` completes successfully and creates `dist/` directory
+
+### MCP Registry Publish Fails
+
+**Problem:** "Package not available after X seconds"
+- **Solution:** Check that npm publish workflow completed successfully first
+- **Solution:** npm may take a few minutes to propagate; try re-running the workflow
+
+**Problem:** "Authentication failed"
+- **Solution:** Verify repository has `id-token: write` permission enabled
+- **Solution:** Check that GitHub Actions is enabled for the repository
+
+**Problem:** "Validation failed"
+- **Solution:** Check `server.json` format using `mcp-publisher validate` locally
+- **Solution:** Ensure package name in server.json matches package.json
+
+### Version Already Exists
+
+**Problem:** "npm ERR! 403 You cannot publish over the previously published versions"
+- **Solution:** Bump the version in `package.json` before creating a new release
+
+## Best Practices
+
+1. **Version Bumping**
+   - Follow semantic versioning (MAJOR.MINOR.PATCH)
+   - Update version in `package.json` AND `server.json` together
+   - Create meaningful release notes
+
+2. **Testing Before Release**
+   - Test the built package locally:
+     ```bash
+     cd mcp-server
+     npm run build
+     npm pack
+     npm install -g ./skillboss-mcp-server-*.tgz
+     skillboss-mcp
+     ```
+
+3. **Release Notes**
+   - Include what's new, changed, fixed
+   - Mention breaking changes prominently
+   - Link to relevant issues/PRs
+
+4. **Monitoring**
+   - Watch workflow logs during publish
+   - Verify package is available on npm
+   - Test installation from npm immediately after publish
+
+## Package Configuration
+
+### package.json
+
+Key fields for publishing:
+
+```json
+{
+  "name": "@skillboss/mcp-server",
+  "version": "1.0.1",
+  "files": ["dist", "README.md"],
+  "main": "dist/index.js",
+  "bin": {
+    "skillboss-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepare": "npm run build"
+  }
+}
+```
+
+- `files`: Specifies what gets included in the npm package
+- `prepare`: Automatically runs before packing/publishing
+- `bin`: Makes the CLI executable available
+
+### server.json
+
+MCP Registry configuration:
+
+```json
+{
+  "name": "io.github.heeyo-life/skillboss",
+  "version": "1.0.1",
+  "packages": [{
+    "registryType": "npm",
+    "identifier": "@skillboss/mcp-server",
+    "version": "1.0.1"
+  }]
+}
+```
+
+- Version in server.json must match package.json
+- `identifier` must match npm package name
+
+## Security Notes
+
+- **NPM_TOKEN**: Keep this secret secure; never commit it to the repository
+- **npm provenance**: Automatically signed using GitHub OIDC for supply chain security
+- **GitHub OIDC**: No secrets needed; uses GitHub's identity system
+- **Access tokens**: Use automation tokens with minimal required permissions
+
+## Support
+
+If you encounter issues:
+
+1. Check workflow logs in GitHub Actions
+2. Verify all secrets are configured correctly
+3. Ensure package.json and server.json versions match
+4. Review this documentation for troubleshooting steps
+
+For additional help, contact the SkillBoss team at support@skillboss.co


### PR DESCRIPTION
## Summary

This PR adds automated publishing workflows to enable releasing the SkillBoss MCP Server to both npm and the Claude Marketplace (MCP Registry). When you create a GitHub release, the package will automatically be published to both registries.

## Changes

### 1. New npm Publishing Workflow (`.github/workflows/npm-publish.yml`)

- Triggers on GitHub releases (when a tag is created)
- Builds TypeScript code in `mcp-server/` directory
- Publishes to npm with provenance (supply chain security)
- Supports dry-run mode for testing
- Verifies build output before publishing
- Publishes as public scoped package (`@skillboss/mcp-server`)

### 2. Updated MCP Registry Workflow (`.github/workflows/mcp-registry-publish.yml`)

- **Key Improvement**: Now waits for npm package to be available before publishing
- Polls npm registry for up to 5 minutes (30 attempts x 10 seconds)
- Only publishes to MCP Registry after npm package is confirmed
- Better error messages and workflow summaries
- Improved step naming and organization

### 3. Comprehensive Documentation

#### `mcp-server/README.md`
- Package overview and features
- Installation instructions for various MCP clients
- Configuration guide
- Development and testing instructions
- Links to documentation and support

#### `mcp-server/RELEASE.md`
- Complete release process guide
- Prerequisites and required GitHub secrets
- Step-by-step release instructions
- Troubleshooting section for common issues
- Security best practices
- Detailed workflow explanations

#### `mcp-server/.npmignore`
- Controls what files are published to npm
- Excludes source files (only publishes compiled `dist/`)
- Excludes development and CI files

## Release Process Flow

1. **Developer bumps version** in `package.json` and `server.json`
2. **Create git tag**: `git tag v1.0.2 && git push origin v1.0.2`
3. **Create GitHub release** (via web UI or `gh release create`)
4. **Workflows execute automatically**:
   - npm publish workflow builds and publishes to npm (~2-3 min)
   - MCP Registry workflow waits for npm package to be available
   - MCP Registry workflow publishes to Claude Marketplace (~2-3 min)
5. **Package is live** on both npm and Claude Marketplace

## Required Setup

### GitHub Secrets

Before this can work in production, you need to add **one secret** to GitHub:

1. **NPM_TOKEN** (Required)
   - Go to [npmjs.com](https://www.npmjs.com) and create an "Automation" token
   - Add to GitHub: Settings → Secrets and variables → Actions → New repository secret
   - Name: `NPM_TOKEN`
   - Value: Your npm token (starts with `npm_...`)

2. **GitHub OIDC** (Automatic - no action needed)
   - Already configured in the workflows
   - GitHub automatically provides OIDC tokens for MCP Registry authentication

## Testing

You can test the npm workflow without actually publishing:

```bash
# Trigger dry-run via GitHub UI
gh workflow run npm-publish.yml -f dry_run=true
```

Or manually test the build process:

```bash
cd mcp-server
npm install
npm run build
npm pack
# Inspect the generated .tgz file
```

## What's Included in the npm Package

Based on the `files` field in `package.json` and `.npmignore`:

- `dist/` - Compiled JavaScript and type definitions
- `README.md` - Package documentation
- `package.json` - Package metadata

Excluded from npm package:
- `src/` - TypeScript source files
- `tsconfig.json` - Build configuration
- Development and CI files
- `RELEASE.md` (internal documentation)

## Benefits

1. **Automated Publishing**: No manual steps needed after creating a release
2. **Supply Chain Security**: npm provenance provides attestation
3. **Error Prevention**: Build verification before publishing
4. **Synchronization**: MCP Registry always gets the exact npm version
5. **Idempotent**: Safe to re-run workflows
6. **Well-Documented**: Clear instructions for maintainers
7. **Testable**: Dry-run mode for npm publish

## Next Steps

After merging this PR:

1. Add `NPM_TOKEN` to GitHub repository secrets
2. Update version in `package.json` and `server.json` to `1.0.2` (or desired version)
3. Create a git tag: `git tag v1.0.2 && git push origin v1.0.2`
4. Create a GitHub release for the tag
5. Watch the workflows execute in the Actions tab
6. Verify publication:
   - npm: `npm view @skillboss/mcp-server`
   - MCP Registry: Check Claude Marketplace

## Documentation

All documentation is included in this PR:
- Release process: `mcp-server/RELEASE.md`
- Package overview: `mcp-server/README.md`
- Workflow files are commented for clarity

## Security

- npm provenance enabled (supply chain attestation)
- Uses GitHub OIDC (no long-lived secrets for MCP Registry)
- NPM_TOKEN stored securely in GitHub secrets
- Minimal permissions for workflows

---

**Ready to merge and enable automated publishing!** 🚀

After merging, the team can publish releases by simply creating GitHub releases. Both npm and the MCP Registry will be automatically updated.