### PR TITLE
fix: backup sub-packs before extracting update zip

### DIFF
--- a/skillboss/install/update.sh
+++ b/skillboss/install/update.sh
@@ -72,6 +72,13 @@ fi
 echo -e "${CYAN}Backing up current installation to $BACKUP_DIR...${NC}"
 mv "$SKILLBOSS_DIR" "$BACKUP_DIR"
 
+# Also backup sub-packs so unzip can replace them with new versions
+for subpack in skillboss-image skillboss-video; do
+    if [ -d "$PARENT_DIR/$subpack" ]; then
+        mv "$PARENT_DIR/$subpack" "$BACKUP_DIR/$subpack"
+    fi
+done
+
 # 6. Extract new version
 echo -e "${CYAN}Extracting new version...${NC}"
 unzip -q "$TEMP_DIR/skillboss.zip" -d "$PARENT_DIR"


### PR DESCRIPTION
## Summary
- update.sh only backed up the main `skillboss/` directory but left sub-packs (`skillboss-image/`, `skillboss-video/`) in place
- Since `unzip` without `-o` skips existing files in non-interactive mode, sub-packs were never updated
- Now we move sub-packs into the backup directory before extracting the new zip

## Metric target
Correctness — ensure all users get updated sub-packs when running update.sh

## Test plan
- [x] Code review: verified `$BACKUP_DIR` exists as directory after main pack backup (line 73 renames skillboss → backup dir)
- [x] Verified sub-pack mv target is inside backup dir (child of existing directory)
- [x] Verified `if [ -d ... ]` guards handle case where sub-packs don't exist
- [x] Bash syntax check passed (`bash -n`)

## Authorization
| 字段 | 值 |
|------|-----|
| 批准人 | ou_5b40b5edb6d516b06829ee9b6a86b8f4 (ou_5b40b5edb6d516b06829ee9b6a86b8f4) |
| 批准时间 | 2026-03-18 13:07 UTC |
| 触发方式 | Lark 消息指令 |

🤖 Generated by SkillBoss Growth Agent